### PR TITLE
Updated dependencies and small bugfix

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -187,7 +187,7 @@ makeDatabase files = do
         L.extensions = [L.MultiParamTypeClasses, L.ExistentialQuantification, L.FlexibleContexts],
         L.ignoreLanguagePragmas = False,
         L.ignoreLinePragmas = False,
-        L.fixities = []
+        L.fixities = Nothing
       }
 
 moduleFile :: L.Module L.SrcSpanInfo -> FilePath

--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -30,7 +30,7 @@ executable hothasktags
     build-depends: 
         base == 4.*,
         containers,
-        haskell-src-exts >= 1.8 && < 1.11,
+        haskell-src-exts == 1.11.*,
         cpphs >= 1.11 && < 1.14
     main-is: Main.hs
     ghc-options: -W


### PR DESCRIPTION
Hi,

I've got a few small fixes to haskell-src-exts:

I've relaxed the dependency on cpphs.

I've also raised the dependency on haskell-src-exts to the newest version. Old versions don't work anymore due to a changed options data type.

Finally, I've changed the cpphs options to generate haskell style line pragmas instead of cpp style, since haskell-src-exts has problems with the latter.
