### PR TITLE
Format package description with haddock markup

### DIFF
--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -9,21 +9,21 @@ category: Development
 synopsis: Generates ctags for Haskell, incorporating import lists and qualified imports
 description: 
     hothasktags generates ctags files for Haskell, with knowledge of import lists 
-    and qualified imports.  It provides a smart go-to-definition for vim, that almost
+    and qualified imports.  It provides a smart go-to-definition for Vim, that almost
     always gets it right in the presence of multiple names from different modules.
-    
-    You will want to configure vim to allow dots in keywords, because hothasktags
+    .
+    You will want to configure Vim to allow dots in keywords, because hothasktags
     generates tags for qualified names.  You can do this with:
-    
-    set iskeyword=a-z,A-Z,_,.,39
-    
+    .
+    > set iskeyword=a-z,A-Z,_,.,39
+    .
     (The 39 is for the prime character)
-    
+    .
     Usage is easy, just give hothasktags the names of all the haskell sources you
     want to index and redirect into a tags file.  For example:
-    
-    find . | egrep '\.hs$' | xargs hothasktags > tags
-    
+    .
+    > find . | egrep '\.hs$' | xargs hothasktags > tags
+    .
     will index all the hs files under the current directory.
 homepage: http://github.com/luqui/hothasktags
 executable hothasktags


### PR DESCRIPTION
So the user gets readable description on the Hackage page instead of current, a bit hard-to-read one long line.

Cheers,
-- m.
