### PR TITLE
loosen package dependency upper bounds

### DIFF
--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -30,7 +30,7 @@ executable hothasktags
     build-depends: 
         base == 4.*,
         containers,
-        haskell-src-exts == 1.11.*,
-        cpphs >= 1.11 && < 1.14
+        haskell-src-exts >= 1.11 && < 1.14,
+        cpphs >= 1.11 && < 1.15
     main-is: Main.hs
     ghc-options: -W


### PR DESCRIPTION
The upstream packages cpphs and haskell-src-exts both have new versions with support for ghc-7.6.
