### PR TITLE
Add entry for file names

### DIFF
--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -30,6 +30,7 @@ executable hothasktags
     build-depends: 
         base == 4.*,
         containers,
+        filepath,
         haskell-src-exts >= 1.11 && < 1.14,
         cpphs >= 1.11 && < 1.15
     main-is: Main.hs


### PR DESCRIPTION
Fully qualified module names are nice, but sometimes you just want to jump to _Filename.hs_ somewhere in your project tree. This patch adds tags for the basenames of the files as they are encountered, so you can do

```
:tag Connection.hs
```

and have it pull up _src/Network/Http/Connection.hs_ which is a nice complement to pull #9 where you can do

```
:tag Network.Http.Connection
```

AfC
