### PR TITLE
cabal install requires cpphs downgrade

### DIFF
--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -8,8 +8,8 @@ license-file: LICENSE
 maintainer: Luke Palmer <lrpalmer@gmail.com>
 category: Development
 synopsis: Generates ctags for Haskell, incorporating import lists and qualified imports
-description: 
-    hothasktags generates ctags files for Haskell, with knowledge of import lists 
+description:
+    hothasktags generates ctags files for Haskell, with knowledge of import lists
     and qualified imports.  It provides a smart go-to-definition for Vim, that almost
     always gets it right in the presence of multiple names from different modules.
     .
@@ -33,11 +33,11 @@ source-repository head
     type: git
     location: git://github.com/luqui/hothasktags.git
 executable hothasktags
-    build-depends: 
+    build-depends:
         base == 4.*,
         containers,
         filepath,
         haskell-src-exts >= 1.11 && < 1.14,
-        cpphs >= 1.11 && < 1.15
+        cpphs >= 1.11 && < 1.17
     main-is: Main.hs
     ghc-options: -W


### PR DESCRIPTION
Installing hothasktags under the latest haskell-platform requires a potentially destructive downgrade:

```
$ cabal install hothasktags
Resolving dependencies...
In order, the following would be installed:
cpphs-1.14 (new version)
haskell-src-exts-1.13.5 (reinstall) changes: cpphs-1.16 -> 1.14
hothasktags-0.3.0 (new package)
cabal: The following packages are likely to be broken by the reinstalls:
hoogle-4.2.15
hlint-1.8.43
HTF-0.10.0.7
Use --force-reinstalls if you want to install anyway.
```

I incremented hothasktag's upper bound on cpphs's version to avoid this.
