### PR TITLE
better command line interface (cmdargs) and bump HSE version

### DIFF
--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -37,7 +37,8 @@ executable hothasktags
         base == 4.*,
         containers,
         filepath,
-        haskell-src-exts >= 1.11 && < 1.14,
-        cpphs >= 1.11 && < 1.17
+        haskell-src-exts >= 1.14,
+        cpphs >= 1.11 && < 1.17,
+        cmdargs
     main-is: Main.hs
     ghc-options: -W


### PR DESCRIPTION
Hi,

To generate tags for a good fraction of the files in `ghc/compiler` I need additional options implemented in this commit:

```
hothasktags -I$PWD/stage2 -c --strip -XCPP -XBangPatterns -XScopedTypeVariables `find -name '*.hs'` >! tag
```

There are still many files that don't parse, but fixing those would involve changing haskell-src-exts I think.

Also mixed in with this commit is a bump in the version of haskell-src-exts required. Only versions >= 1.14 are supported now.
