### PR TITLE
Compile against haskell-src-exts 1.16

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -37,6 +37,7 @@ localDecls (L.Module _ _ _ _ decls) = Map.fromList $ concatMap extract decls
     extractDeclHead (L.DHead _ name) = extractName name
     extractDeclHead (L.DHInfix _ _ name) = extractName name
     extractDeclHead (L.DHParen _ head') = extractDeclHead head'
+    extractDeclHead (L.DHApp _ head' _) = extractDeclHead head'
 
     extractPat (L.PVar _ name) = extractName name
     extractPat (L.PApp _ _ pats) = concatMap extractPat pats

--- a/Main.hs
+++ b/Main.hs
@@ -30,12 +30,12 @@ localDecls (L.Module _ _ _ _ decls) = Map.fromList $ concatMap extract decls
     extract (L.TypeSig _ names _) = concatMap extractName names
     extract (L.FunBind _ (L.Match _ name _ _ _ : _)) = extractName name
     extract (L.FunBind _ (L.InfixMatch _ _ name _ _ _ : _)) = extractName name
-    extract (L.PatBind _ pat _ _ _) = extractPat pat
+    extract (L.PatBind _ pat _ _) = extractPat pat
     extract (L.ForImp _ _ _ _ name _) = extractName name
     extract _ = []
 
-    extractDeclHead (L.DHead _ name _) = extractName name
-    extractDeclHead (L.DHInfix _ _ name _) = extractName name
+    extractDeclHead (L.DHead _ name) = extractName name
+    extractDeclHead (L.DHInfix _ _ name) = extractName name
     extractDeclHead (L.DHParen _ head') = extractDeclHead head'
 
     extractPat (L.PVar _ name) = extractName name
@@ -55,7 +55,7 @@ localDecls (L.Module _ _ _ _ decls) = Map.fromList $ concatMap extract decls
 
     extractFieldDecl (L.FieldDecl _ names _) = concatMap extractName names
 
-    extractGadtDecl (L.GadtDecl _ name _) = extractName name
+    extractGadtDecl (L.GadtDecl _ name _ _) = extractName name
 
     extractClassDecl (L.ClsDecl _ decl) = extract decl
     extractClassDecl (L.ClsDataFam _ _ head _) = extractDeclHead head
@@ -82,19 +82,19 @@ thingMembers (L.Module _ _ _ _ decls) name = concatMap extract decls
     getQualConDecl (L.QualConDecl _ _ _ (L.RecDecl _ (L.Ident _ name) fields)) = name : concatMap getField fields
     getQualConDecl _ = []
 
-    getGadtDecl (L.GadtDecl _ name _) = getName name
+    getGadtDecl (L.GadtDecl _ name _ _) = getName name
     
     getField (L.FieldDecl _ names _) = concatMap getName names
 
     getClassDecl (L.ClsDecl _ (L.FunBind _ (L.Match _ name _ _ _ : _))) = getName name
-    getClassDecl (L.ClsDecl _ (L.PatBind _ (L.PVar _ name) _ _ _)) = getName name  
+    getClassDecl (L.ClsDecl _ (L.PatBind _ (L.PVar _ name) _ _)) = getName name  
     getClassDecl _ = []
 
     getName (L.Ident _ name) = [name]
     getName _ = []
 
-    nameOfHead (L.DHead _ (L.Ident _ name) _) = Just name
-    nameOfHead (L.DHInfix _ _ (L.Ident _ name) _) = Just name
+    nameOfHead (L.DHead _ (L.Ident _ name)) = Just name
+    nameOfHead (L.DHInfix _ _ (L.Ident _ name)) = Just name
     nameOfHead (L.DHParen _ h) = nameOfHead h
     nameOfHead _ = Nothing
 thingMembers _ _ = []
@@ -108,7 +108,7 @@ modExports db modname =
 exported :: L.Module L.SrcSpanInfo -> String -> Bool
 exported mod@(L.Module _ (Just (L.ModuleHead _ _ _ (Just (L.ExportSpecList _ specs)))) _ _ _) name = any (matchesSpec name) specs
     where
-    matchesSpec name (L.EVar _ (L.UnQual _ (L.Ident _ name'))) = name == name'
+    matchesSpec name (L.EVar _ _ (L.UnQual _ (L.Ident _ name'))) = name == name'
     matchesSpec name (L.EAbs _ (L.UnQual _ (L.Ident _ name'))) = name == name'
     matchesSpec name (L.EThingAll _ (L.UnQual _ (L.Ident _ name'))) = name == name' || (name `elem` thingMembers mod name')
     matchesSpec name (L.EThingWith _ (L.UnQual _ (L.Ident _ name')) cnames) = name == name' || any (matchesCName name) cnames
@@ -151,7 +151,7 @@ moduleScope db mod@(L.Module _ modhead _ imports _) = Map.unions $ moduleItself 
 
         normalExports = modExports db name
 
-        specName (L.IVar _ (L.Ident _ name)) = [name]
+        specName (L.IVar _ _ (L.Ident _ name)) = [name]
         specName (L.IAbs _ (L.Ident _ name)) = [name]
         specName (L.IThingAll _ (L.Ident _ name)) = [name]  -- XXX incorrect, need its member names
         specName (L.IThingWith _ (L.Ident _ name) cnames) = name : concatMap cname cnames


### PR DESCRIPTION
Adjust constructors (which are full of nothing buy `_` anyway) so that **hothasktags** builds again. Since there's no test suite I can't say whether this is actually been correct, but cursory testing showed the `tags` file was valid.

Closes luqui/hothasktags#20, maybe.

AfC
