### PR TITLE
Update for src-exts <1.18 and cpphs <1.21

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -131,8 +131,8 @@ exported mod'@(L.Module _
                       (Just (L.ExportSpecList _ specs)))) _ _ _) name =
     any (matchesSpec name) specs
   where
-    matchesSpec nm (L.EVar _ _ (L.UnQual _ (L.Ident _ name'))) = nm == name'
-    matchesSpec nm (L.EAbs _ (L.UnQual _ (L.Ident _ name'))) = nm == name'
+    matchesSpec nm (L.EVar _ (L.UnQual _ (L.Ident _ name'))) = nm == name'
+    matchesSpec nm (L.EAbs _ _ (L.UnQual _ (L.Ident _ name'))) = nm == name'
     matchesSpec nm (L.EThingAll _ (L.UnQual _ (L.Ident _ name'))) =
       nm == name' || (nm `elem` thingMembers mod' name')
     matchesSpec nm (L.EThingWith _ (L.UnQual _ (L.Ident _ name')) cnames) =
@@ -189,8 +189,8 @@ moduleScope db mod'@(L.Module _ modhead _ imports _) =
 
           normalExports = modExports db name
 
-          specName (L.IVar _ _ (L.Ident _ name')) = [name']
-          specName (L.IAbs _ (L.Ident _ name')) = [name']
+          specName (L.IVar _ (L.Ident _ name')) = [name']
+          specName (L.IAbs _ _ (L.Ident _ name')) = [name']
           -- XXX incorrect, need its member names
           specName (L.IThingAll _ (L.Ident _ name')) = [name']
           specName (L.IThingWith _ (L.Ident _ name') cnames) =

--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -38,8 +38,8 @@ executable hothasktags
         filepath,
         filemanip,
         Glob,
-        haskell-src-exts >= 1.14,
-        cpphs >= 1.11 && < 1.20,
+        haskell-src-exts >= 1.17 && < 1.18,
+        cpphs >= 1.11 && < 1.21,
         optparse-applicative,
         split
     main-is: Main.hs


### PR DESCRIPTION
Hello,

This branch fixes hothasktags with src-exts 1.17 -- at present hothasktags is broken because it does not specify an upper bound on src-exts -- and also raises the bound on cpphs since it works fine with cpphs 1.12.

Thanks.