### PR TITLE
Add import to fix compilation errors.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -18,6 +18,7 @@ import Data.Maybe (fromMaybe)
 import Data.List.Split (endBy)
 import System.FilePath.Find
 import "Glob" System.FilePath.Glob
+import Data.Monoid
 
 type Database = Map.Map String (L.Module L.SrcSpanInfo)
 type LineInfo = Map.Map FilePath (A.Array Int (HandlePosition, String))


### PR DESCRIPTION
I couldn't get hothasktags to compile either using cabal or using make from within the repo. So I've added `import Data.Monoid` (yes that is the extent of this PR!) and it compiled properly and it produces a correct tags file.

I should point out here that I am a super newb so I may have committed an egregious error, please forgive me if I have a discard this PR :)

Some versions:

* cabal: 1.24.0.0
* ghc: 8.0.1