### PR TITLE
Main.hs: tweak (<>) import for optparse-applicative-0.13

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -15,6 +15,7 @@ import Control.Monad
 import qualified Data.Array.Unboxed as A
 import Data.List (sort)
 import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
 import Data.List.Split (endBy)
 import System.FilePath.Find
 import "Glob" System.FilePath.Glob

--- a/hothasktags.cabal
+++ b/hothasktags.cabal
@@ -40,7 +40,7 @@ executable hothasktags
         Glob,
         haskell-src-exts >= 1.17 && < 1.18,
         cpphs >= 1.11 && < 1.21,
-        optparse-applicative,
+        optparse-applicative >= 0.13,
         split
     main-is: Main.hs
     ghc-options: -W


### PR DESCRIPTION
optparse-applicative-0.13 stopped exporting (<>) in favour
of Monoid instance and the build now fails as:

```
  Main.hs:305:8: error:
    • Variable not in scope: (<>) :: Mod f3 a5 -> Mod f2 a4 -> t1
    • Perhaps you meant one of these:
        ‘<$>’ (imported from Options.Applicative),
        ‘<*>’ (imported from Options.Applicative),
        ‘*>’ (imported from Options.Applicative)
```

Signed-off-by: Sergei Trofimovich <siarheit@google.com>